### PR TITLE
Update Faraday and Middleware Gems to be compatible with Rails 3.2

### DIFF
--- a/lib/rdio_api/api.rb
+++ b/lib/rdio_api/api.rb
@@ -22,7 +22,7 @@ module RdioApi
     private
       
     def unauthenticated_request(method_sym, *arguments)
-      response = unauthenticated_connection.post do |request|
+      response = unauthenticated_connection.post(api_url) do |request|
         request.body = {:method => method_sym.to_s}.merge!(Hash[*arguments.flatten])
       end
       response.body.result

--- a/rdio_api.gemspec
+++ b/rdio_api.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rb-fsevent'
   s.add_development_dependency 'guard-rspec'
   
-  s.add_runtime_dependency 'faraday', '~> 0.6.1'
-  s.add_runtime_dependency 'faraday_middleware', '~> 0.6.5'
-  s.add_runtime_dependency 'hashie', '~> 1.0.0'
-  s.add_runtime_dependency 'multi_json', '~> 1.0.3'
+  s.add_runtime_dependency 'faraday', '~> 0.8.0'
+  s.add_runtime_dependency 'faraday_middleware', '~> 0.8.7'
+  s.add_runtime_dependency 'hashie', '~> 1.2.0'
+  s.add_runtime_dependency 'multi_json', '~> 1.3.0'
   s.add_runtime_dependency 'simple_oauth', '~> 0.1.5'
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
This pull enables the gem to be compatible with Rails 3.2. All specs are passing.
