### PR TITLE
Update README to account for changed link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Rdio
 ====================
-Ruby wrapper for the [Rdio](http://rdio.com) API. Inspired by [Linkedin gem](https://github.com/pengwynn/linkedin) & [Twitter gem](https://github.com/jnunemaker/twitter).
+Ruby wrapper for the [Rdio](http://rdio.com) API. Inspired by [Linkedin gem](https://github.com/pengwynn/linkedin) & [Twitter gem](https://github.com/sferik/twitter).
 
 
 Installation


### PR DESCRIPTION
Update link to Twitter gem. Per https://github.com/jnunemaker/twitter, "The twitter gem has moved to https://github.com/sferik/twitter."
