### PR TITLE
Multi json semantic versioning

### DIFF
--- a/rdio_api.gemspec
+++ b/rdio_api.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'faraday', '~> 0.8.0'
   s.add_runtime_dependency 'faraday_middleware', '~> 0.8.7'
   s.add_runtime_dependency 'hashie', '~> 1.2.0'
-  s.add_runtime_dependency 'multi_json', '~> 1.3.0'
+  s.add_runtime_dependency 'multi_json', '~> 1.3'
 
   s.add_runtime_dependency 'simple_oauth', '~> 0.1.5'
 


### PR DESCRIPTION
Since multi_json uses semantic versioning, specifying the patch level is unnecessary. (And, in fact, can create frustrating conflicts…as it did today after multi_json 1.4.0 was released.) This update fixes that. No backwards-incompatible changes will be introduced to multi_json except in a major version bump.
